### PR TITLE
fixed timer bad timer check call

### DIFF
--- a/views/confirm.ejs
+++ b/views/confirm.ejs
@@ -18,8 +18,9 @@
             <%- include ('partials/timer', {timeEstimate: details.timeEstimate}) %>
             <script>
                 setInterval(async function() {
-                   let res = await fetch('http://localhost:3000/logs/check/<%= details.batchId %>');
+                   let res = await fetch(window.location.protocol + "//" + window.location.host + '/logs/check/<%= details.batchId %>');
                    let json = await res.json();
+                   console.log('checking for log completion', json)
                    if (json.complete) {
                         window.location.href = '/logs/<%= details.batchId %>';
                     } 


### PR DESCRIPTION
* replace hard-coded `localhost` with window.location for /logs/check call in `confirm.ejs`
* this is port-agnostic and works on the server